### PR TITLE
Add word-wrap to body element

### DIFF
--- a/.dev/sass/components/_typography.scss
+++ b/.dev/sass/components/_typography.scss
@@ -1,6 +1,7 @@
 body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	word-wrap: break-word;
 }
 
 body,

--- a/.dev/sass/layouts/_posts-and-pages.scss
+++ b/.dev/sass/layouts/_posts-and-pages.scss
@@ -109,6 +109,10 @@
 	margin: 1.5em 0 0;
 }
 
+.entry-content {
+	margin-bottom: 1.5em;
+}
+
 .entry-footer {
 	font-size: 85%;
 	color: $color__text-secondary;

--- a/editor-style-rtl.css
+++ b/editor-style-rtl.css
@@ -192,7 +192,8 @@ textarea {
 
 body {
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
+  -moz-osx-font-smoothing: grayscale;
+  word-wrap: break-word; }
 
 body,
 button,

--- a/editor-style.css
+++ b/editor-style.css
@@ -192,7 +192,8 @@ textarea {
 
 body {
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
+  -moz-osx-font-smoothing: grayscale;
+  word-wrap: break-word; }
 
 body,
 button,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2189,6 +2189,9 @@ body.no-max-width .site-info-wrapper .site-info {
 .entry-summary {
   margin: 1.5em 0 0; }
 
+.entry-content {
+  margin-bottom: 1.5em; }
+
 .entry-footer {
   font-size: 85%;
   color: #686868; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -240,7 +240,8 @@ textarea {
 --------------------------------------------------------------*/
 body {
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
+  -moz-osx-font-smoothing: grayscale;
+  word-wrap: break-word; }
 
 body,
 button,

--- a/style.css
+++ b/style.css
@@ -2189,6 +2189,9 @@ body.no-max-width .site-info-wrapper .site-info {
 .entry-summary {
   margin: 1.5em 0 0; }
 
+.entry-content {
+  margin-bottom: 1.5em; }
+
 .entry-footer {
   font-size: 85%;
   color: #686868; }

--- a/style.css
+++ b/style.css
@@ -240,7 +240,8 @@ textarea {
 --------------------------------------------------------------*/
 body {
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
+  -moz-osx-font-smoothing: grayscale;
+  word-wrap: break-word; }
 
 body,
 button,


### PR DESCRIPTION
- Add word-wrap to body element to prevent long words from overflowing.
- Added a bottom margin to the page/post content, to space out the navigation items.
