### PR TITLE
Set max width, adjust z-index

### DIFF
--- a/.dev/sass/components/_menus.scss
+++ b/.dev/sass/components/_menus.scss
@@ -269,7 +269,7 @@ body.no-max-width .main-navigation {
 	top: 20px;
 	right: 0;
 	display: block;
-	padding: 0 9px 24px 0;
+	padding: 0 10px 24px 0;
 	z-index: 99999;
 
 	.admin-bar &{

--- a/.dev/sass/components/_menus.scss
+++ b/.dev/sass/components/_menus.scss
@@ -6,7 +6,7 @@
 		top: 0;
 		left: 0;
 		right: 0;
-		z-index: 9999;
+		z-index: 9;
 	}
 }
 
@@ -334,6 +334,3 @@ body.no-max-width .main-navigation {
 		width: 50%;
 	}
 }
-
-
-

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -44,7 +44,6 @@
 	@media #{$small-only} {
 		position: absolute;
 		width: auto;
-		z-index: 999999;
 		max-width: 90%;
 		z-index: 8;
 	}

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -45,6 +45,8 @@
 		position: absolute;
 		width: auto;
 		z-index: 999999;
+		max-width: 90%;
+		z-index: 8;
 	}
 
 	.site-title {

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -42,7 +42,7 @@
 	}
 
 	@media #{$small-only} {
-		position: absolute;
+		position: relative;
 		width: auto;
 		max-width: 90%;
 		z-index: 8;

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -71,7 +71,6 @@
 
 	@media #{$small-only} {
 		position: relative;
-		top: 80px;
 		padding-bottom: 100px;
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -791,7 +791,7 @@ body.no-max-width .main-navigation {
   top: 20px;
   left: 0;
   display: block;
-  padding: 0 0 24px 9px;
+  padding: 0 0 24px 10px;
   z-index: 99999; }
   .admin-bar .menu-toggle {
     top: 48px; }
@@ -1630,7 +1630,7 @@ body.page-template-page-builder-no-header .content-area {
       padding-top: 7%; } }
   @media only screen and (max-width: 40.063em) {
     .site-title-wrapper {
-      position: absolute;
+      position: relative;
       width: auto;
       max-width: 90%;
       z-index: 8; } }
@@ -1760,7 +1760,6 @@ body.no-max-width .page-title-container .page-header {
   @media only screen and (max-width: 40.063em) {
     .hero {
       position: relative;
-      top: 80px;
       padding-bottom: 100px; } }
 
 /*--------------------------------------------------------------

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -600,7 +600,7 @@ a {
       top: 0;
       right: 0;
       left: 0;
-      z-index: 9999; } }
+      z-index: 9; } }
 
 .main-navigation {
   max-width: 1100px;
@@ -1632,7 +1632,9 @@ body.page-template-page-builder-no-header .content-area {
     .site-title-wrapper {
       position: absolute;
       width: auto;
-      z-index: 999999; } }
+      z-index: 999999;
+      max-width: 90%;
+      z-index: 8; } }
   .site-title-wrapper .site-title {
     text-transform: uppercase;
     letter-spacing: 1px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1632,7 +1632,6 @@ body.page-template-page-builder-no-header .content-area {
     .site-title-wrapper {
       position: absolute;
       width: auto;
-      z-index: 999999;
       max-width: 90%;
       z-index: 8; } }
   .site-title-wrapper .site-title {

--- a/style.css
+++ b/style.css
@@ -600,7 +600,7 @@ a {
       top: 0;
       left: 0;
       right: 0;
-      z-index: 9999; } }
+      z-index: 9; } }
 
 .main-navigation {
   max-width: 1100px;
@@ -1632,7 +1632,9 @@ body.page-template-page-builder-no-header .content-area {
     .site-title-wrapper {
       position: absolute;
       width: auto;
-      z-index: 999999; } }
+      z-index: 999999;
+      max-width: 90%;
+      z-index: 8; } }
   .site-title-wrapper .site-title {
     text-transform: uppercase;
     letter-spacing: 1px;

--- a/style.css
+++ b/style.css
@@ -1632,7 +1632,6 @@ body.page-template-page-builder-no-header .content-area {
     .site-title-wrapper {
       position: absolute;
       width: auto;
-      z-index: 999999;
       max-width: 90%;
       z-index: 8; } }
   .site-title-wrapper .site-title {

--- a/style.css
+++ b/style.css
@@ -791,7 +791,7 @@ body.no-max-width .main-navigation {
   top: 20px;
   right: 0;
   display: block;
-  padding: 0 9px 24px 0;
+  padding: 0 10px 24px 0;
   z-index: 99999; }
   .admin-bar .menu-toggle {
     top: 48px; }
@@ -1630,7 +1630,7 @@ body.page-template-page-builder-no-header .content-area {
       padding-top: 7%; } }
   @media only screen and (max-width: 40.063em) {
     .site-title-wrapper {
-      position: absolute;
+      position: relative;
       width: auto;
       max-width: 90%;
       z-index: 8; } }
@@ -1760,7 +1760,6 @@ body.no-max-width .page-title-container .page-header {
   @media only screen and (max-width: 40.063em) {
     .hero {
       position: relative;
-      top: 80px;
       padding-bottom: 100px; } }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
This patch sets a max-width on the `.site-title-wrapper` element on the small breakpoint (mobile devices). The max width sets to 90%, to prevent text and the menu button from overlapping.

Additionally, the menu button z-index is now set to 9, down from 9999. And the `.site-title-wrapper` element has a z-index of 8, to prevent it from taking z-index priority over the menu button (preventing the click and menu button from working).
