### PR TITLE
Add replace:charset to the watch:sass Grunt.js task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,7 +185,7 @@ module.exports = function( grunt ) {
 			},
 			sass: {
 				files: '.dev/sass/**/*.scss',
-				tasks: [ 'sass', 'autoprefixer', 'cssjanus' ]
+				tasks: [ 'sass', 'replace:charset', 'autoprefixer', 'cssjanus' ]
 			}
 		},
 


### PR DESCRIPTION
While `grunt:watch` is running, each time a sass file is processed `@charset "UTF-8";` exists at the top of the style.css file until the default grunt task or the `watch:sass` task is run.

Adding `replace:charset` to the `watch:sass` task will prevent the charset from being appended to the top of the style file.