### PR TITLE
Add tested up to/requires php to style.css headers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 **Contributors:** [godaddy](https://profiles.wordpress.org/godaddy), [jonathanbardo](https://profiles.wordpress.org/jonathanbardo), [fjarrett](https://profiles.wordpress.org/fjarrett), [eherman24](https://profiles.wordpress.org/eherman24)  
 **Tags:**              [custom-background](https://wordpress.org/themes/tags/custom-background/), [custom-colors](https://wordpress.org/themes/tags/custom-colors/), [custom-header](https://wordpress.org/themes/tags/custom-header/), [custom-menu](https://wordpress.org/themes/tags/custom-menu/), [editor-style](https://wordpress.org/themes/tags/editor-style/), [featured-images](https://wordpress.org/themes/tags/featured-images/), [flexible-header](https://wordpress.org/themes/tags/flexible-header/), [left-sidebar](https://wordpress.org/themes/tags/left-sidebar/), [one-column](https://wordpress.org/themes/tags/one-column/), [right-sidebar](https://wordpress.org/themes/tags/right-sidebar/), [rtl-language-support](https://wordpress.org/themes/tags/rtl-language-support/), [sticky-post](https://wordpress.org/themes/tags/sticky-post/), [threaded-comments](https://wordpress.org/themes/tags/threaded-comments/), [three-columns](https://wordpress.org/themes/tags/three-columns/), [translation-ready](https://wordpress.org/themes/tags/translation-ready/), [two-columns](https://wordpress.org/themes/tags/two-columns/)  
 **Requires at least:** 4.4  
-**Tested up to:**      4.9  
+**Tested up to:**      5.4  
 **Requires PHP:**      5.6.0  
 **Stable tag:**        1.2.2  
 **License:**           GPL-2.0  

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      godaddy, jonathanbardo, fjarrett, eherman24
 Tags:              custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-images, flexible-header, left-sidebar, one-column, right-sidebar, rtl-language-support, sticky-post, threaded-comments, three-columns, translation-ready, two-columns
 Requires at least: 4.4
-Tested up to:      4.9
+Tested up to:      5.4
 Requires PHP:      5.6.0
 Stable tag:        1.2.2
 License:           GPL-2.0

--- a/style.css
+++ b/style.css
@@ -5,6 +5,8 @@
  * Author URI: https://www.godaddy.com/
  * Description: Activation is a Primer child theme with a colorful, fitness-focused design.
  * Version: 1.2.2
+ * Tested up to: 5.0
+ * Requires PHP: 5.6
  * License: GPL-2.0
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: activation

--- a/style.css
+++ b/style.css
@@ -5,8 +5,8 @@
  * Author URI: https://www.godaddy.com/
  * Description: Activation is a Primer child theme with a colorful, fitness-focused design.
  * Version: 1.2.2
- * Tested up to: 5.0
- * Requires PHP: 5.6
+ * Tested up to: 5.4
+ * Requires PHP: 5.6.0
  * License: GPL-2.0
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: activation


### PR DESCRIPTION
Two new header fields have been added as requirements for themes. We need to update style.css to reflect those new requirements.

Tested up to
Requires PHP

The new requirements were posted on the make.wordpress.org/themes blog.